### PR TITLE
Replace line comments with block comments

### DIFF
--- a/babel-repl.el
+++ b/babel-repl.el
@@ -103,7 +103,7 @@ string (as STRING)."
 beg (as BEG)
 end (as END)."
   (let ((comment (replace-regexp-in-string
-                  "//\\([^\n\r]+\\)" "/*\\1 */"
+                  "//\\([^\n\r]*\\)" "/*\\1 */"
                   (buffer-substring-no-properties beg end))))
     (let ((string (replace-regexp-in-string "[\n|\r]+" " " comment)))
       (babel-repl-send-string string))))

--- a/babel-repl.el
+++ b/babel-repl.el
@@ -102,8 +102,11 @@ string (as STRING)."
   "Send the region from beg to end to babel process.
 beg (as BEG)
 end (as END)."
-  (let ((string (replace-regexp-in-string "[\n|\r]+" "" (buffer-substring-no-properties beg end))))
-    (babel-repl-send-string string)))
+  (let ((comment (replace-regexp-in-string
+                  "//\\([^\n\r]+\\)" "/*\\1 */"
+                  (buffer-substring-no-properties beg end))))
+    (let ((string (replace-regexp-in-string "[\n|\r]+" " " comment)))
+      (babel-repl-send-string string))))
 
 (defun babel-repl-send-current-region ()
   "Send the selected region to babel shell process."


### PR DESCRIPTION
Transforms line comments (// ...) to block comments (/\* ... */) before sending the region to babel-repl. Otherwise the line comments run into the code on next line when all newlines are eliminated.
